### PR TITLE
Potential Fix of Infinite Looping in Shipping Address

### DIFF
--- a/src/reactapp/src/api/cart/setShippingAddress/modifier.js
+++ b/src/reactapp/src/api/cart/setShippingAddress/modifier.js
@@ -1,6 +1,7 @@
 /* eslint-disable no-param-reassign */
 import _get from 'lodash.get';
 import { config } from '../../../config';
+import { prepareFullName } from '../../customer/utility';
 
 export function modifySelectedShippingMethod(addressList) {
   const addrWithShippingMethod = addressList.find(
@@ -54,38 +55,33 @@ export function modifyShippingMethods(addressList) {
 }
 
 export function modifyShippingAddressList(addressList) {
-  return addressList.reduce(
-    (
-      addressItems,
-      {
-        company,
-        firstname,
-        lastname,
-        street,
-        telephone: phone,
-        postcode: zipcode,
-        city,
-        country: { code: countryCode },
-        region: { code: regionCode },
-      },
-      index
-    ) => {
-      addressItems[`address_${index + 1}`] = {
-        company,
-        firstname,
-        lastname,
-        street,
-        phone,
-        zipcode,
-        city,
-        region: regionCode,
-        country: countryCode,
-      };
+  return addressList.reduce((addressItems, address, index) => {
+    const {
+      company,
+      firstname,
+      lastname,
+      street,
+      telephone: phone,
+      postcode: zipcode,
+      city,
+      country: { code: countryCode },
+      region: { code: regionCode },
+    } = address;
+    addressItems[`address_${index + 1}`] = {
+      company,
+      firstname,
+      lastname,
+      fullName: prepareFullName(address),
+      street,
+      phone,
+      zipcode,
+      city,
+      region: regionCode,
+      country: countryCode,
+    };
 
-      return addressItems;
-    },
-    {}
-  );
+    return addressItems;
+  }, {});
 }
 
 export default function setShippingAddressModifier(result) {

--- a/src/reactapp/src/components/Checkout/Form/AddressBox.jsx
+++ b/src/reactapp/src/components/Checkout/Form/AddressBox.jsx
@@ -8,8 +8,10 @@ import { modifyAddrObjListToArrayList } from '../../../utils/address';
 import { _toString } from '../../../utils';
 import useShippingAddressContext from '../../../hook/form/useShippingAddressContext';
 import useShippingAddrCartContext from '../../../hook/cart/useShippingAddrCartContext';
+import useShippingAddrAppContext from '../../../hook/cart/useShippingAddrAppContext';
 
 function AddressBox() {
+  const { isLoggedIn } = useShippingAddrAppContext();
   const {
     selectedAddressId,
     setCartSelectedShippingAddress,
@@ -40,7 +42,7 @@ function AddressBox() {
           className="text-sm underline cursor-pointer"
           onClick={newAddressClickHandler}
         >
-          Create a new address
+          {isLoggedIn ? 'Create a new address' : 'Use another address'}
         </span>
       </div>
       <div className="flex items-center justify-center my-2 italic font-semibold">

--- a/src/reactapp/src/components/Checkout/Form/ShippingAddress.jsx
+++ b/src/reactapp/src/components/Checkout/Form/ShippingAddress.jsx
@@ -26,12 +26,12 @@ function ShippingAddress() {
     isFormValid,
     submitHandler,
     editMode,
-    setFormToEditMode,
     setFormEditMode,
     saveAddressHandler,
   } = useShippingAddressContext();
+  const cartHasShippingAddress = !_isObjEmpty(shippingAddressList);
   const customerHasAddress =
-    !_isObjEmpty(customerAddressList) || !_isObjEmpty(shippingAddressList);
+    !_isObjEmpty(customerAddressList) || cartHasShippingAddress;
 
   const cancelAddressEditHandler = useCallback(() => {
     const shippingAddrId = LocalStorage.getCustomerShippingAddressId();
@@ -58,7 +58,7 @@ function ShippingAddress() {
         title="Shipping information"
         context={ShippingAddressFormContext}
       >
-        {isLoggedIn ? (
+        {isLoggedIn || (!isLoggedIn && cartHasShippingAddress) ? (
           <div className="flex items-center justify-around mt-2">
             <Button click={cancelAddressEditHandler} variant="warning">
               cancel
@@ -92,14 +92,6 @@ function ShippingAddress() {
         <div className="py-2">
           <AddressBox address={shippingAddress} />
         </div>
-
-        {!isLoggedIn && (
-          <div className="flex items-center justify-center mt-2">
-            <Button click={setFormToEditMode} variant="warning">
-              edit
-            </Button>
-          </div>
-        )}
       </ToggleBox>
     </Card>
   );

--- a/src/reactapp/src/context/Form/ShippingAddress/ShippingAddressFormManager.jsx
+++ b/src/reactapp/src/context/Form/ShippingAddress/ShippingAddressFormManager.jsx
@@ -80,6 +80,7 @@ function ShippingAddressFormManager({ children }) {
   const stateInfo = _get(stateList, `${shippingCountry}`, []).find(
     s => s.code === shippingRegion
   );
+  const cartHasShippingAddress = isCartHoldingShippingAddress(cartInfo);
 
   const formSubmit = useCallback(
     async (formValues, customerAddressId) => {
@@ -186,34 +187,34 @@ function ShippingAddressFormManager({ children }) {
   // in different occasions
   useEffect(() => {
     let addressId;
-    const cartHoldsShippingAddr = isCartHoldingShippingAddress(cartInfo);
-
     // guest checkout; cart contains an address; then, set address id as selected.
-    if (!isLoggedIn && cartHoldsShippingAddr) {
-      addressId = getFirstItemIdFromShippingAddrList(shippingAddressList);
+    if (!isLoggedIn && cartHasShippingAddress) {
+      addressId = _toString(
+        getFirstItemIdFromShippingAddrList(shippingAddressList)
+      );
     }
     // customer checkout; no cart address present; customer has a default shipping
     // address, then, set the default shipping address as selected.
-    else if (isLoggedIn && !cartHoldsShippingAddr && defaultShippingAddress) {
-      addressId = defaultShippingAddress;
+    else if (isLoggedIn && !cartHasShippingAddress && defaultShippingAddress) {
+      addressId = _toString(defaultShippingAddress);
     }
     // customer checkout; cart contains an address; so the cart address is a new
     // address; hence set it to "new"
     else if (
       isLoggedIn &&
-      cartHoldsShippingAddr &&
+      cartHasShippingAddress &&
       !selectedAddressId &&
       !editMode
     ) {
       addressId = 'new';
     }
 
-    if (addressId) {
-      setCartSelectedShippingAddress(_toString(addressId));
+    if (addressId && addressId !== selectedAddressId) {
+      setCartSelectedShippingAddress(addressId);
     }
   }, [
     editMode,
-    cartInfo,
+    cartHasShippingAddress,
     isLoggedIn,
     selectedAddressId,
     shippingAddressList,

--- a/src/reactapp/tailwind.config.js
+++ b/src/reactapp/tailwind.config.js
@@ -65,7 +65,6 @@ module.exports = {
   },
   plugins: [customFormsPlugin, customMinHeightPlugin],
   purge: {
-    enabled: true,
     content: [
       '../../../../../reactapp/src/**/*.jsx',
       '../../../templates/*.phtml',


### PR DESCRIPTION
All of the below is applicable to guest checkout.

- Potential fix for the infinite looping happening from the `useEffect` inside the `ShippingAddressManager`.
- Fix: shipping address card does not possess the full name of the user in the case of the cart holds a shipping address.
- Fix: Changing the label to "Use another address" in the case of guest checkout instead of "Create new address".
- Fix: Show cancel button in the case of shipping address edit