### PR TITLE
add alias in config-overrides.js

### DIFF
--- a/src/reactapp/config-overrides.js
+++ b/src/reactapp/config-overrides.js
@@ -34,6 +34,7 @@ module.exports = function override(config, env) {
         //
         // react: 'preact/compat',
         // 'react-dom': 'preact/compat',
+	'@hyva/payments' : '../../../../../../../../../../vendor/hyva-themes/magento2-hyva-checkout/src/reactapp/src'
       },
     },
   };


### PR DESCRIPTION
This assumes that the hyva-checkout will be installed by composer and placed in .../vendor/hyva-themes/....

3rd party payment methods can reference core components by using the '@hyva/payments' alias

for example 

import Card from '@hyva/payments/components/common/Card';
