### PR TITLE
adjust config-overrides so that preact is only aliased when isEnvProduction is truthy

### DIFF
--- a/src/reactapp/config-overrides.js
+++ b/src/reactapp/config-overrides.js
@@ -30,7 +30,7 @@ module.exports = function override(config, env) {
     baseConfig.resolve.alias = {
       react: 'preact/compat',
       'react-dom': 'preact/compat',
-      ...config.resolve.alias
+      ...baseConfig.resolve.alias
     };
   }
 

--- a/src/reactapp/config-overrides.js
+++ b/src/reactapp/config-overrides.js
@@ -8,7 +8,7 @@ module.exports = function override(config, env) {
     ? '../../view/frontend/web/js/[name].chunk.js'
     : isEnvDevelopment && 'static/js/[name].chunk.js';
 
-  return {
+  const baseConfig = {
     ...config,
     output: {
       ...config.output,
@@ -24,17 +24,14 @@ module.exports = function override(config, env) {
         name: false,
       },
     },
-    resolve: {
-      ...config.resolve,
-      alias: {
-        ...config.resolve.alias,
-        // Uncomment these to reduce the size of the compiled app
-        // this improves performance, but you loose compatibility
-        // with the React browser extension for debugging
-        //
-        // react: 'preact/compat',
-        // 'react-dom': 'preact/compat',
-      },
-    },
   };
+
+  if (isEnvProduction) {
+    baseConfig.resolve.alias = {
+      react: 'preact/compat',
+      'react-dom': 'preact/compat',
+    };
+  }
+
+  return baseConfig;
 };

--- a/src/reactapp/config-overrides.js
+++ b/src/reactapp/config-overrides.js
@@ -30,6 +30,7 @@ module.exports = function override(config, env) {
     baseConfig.resolve.alias = {
       react: 'preact/compat',
       'react-dom': 'preact/compat',
+      ...config.resolve.alias
     };
   }
 

--- a/src/reactapp/config-overrides.js
+++ b/src/reactapp/config-overrides.js
@@ -28,9 +28,9 @@ module.exports = function override(config, env) {
 
   if (isEnvProduction) {
     baseConfig.resolve.alias = {
+      ...baseConfig.resolve.alias,
       react: 'preact/compat',
       'react-dom': 'preact/compat',
-      ...baseConfig.resolve.alias
     };
   }
 


### PR DESCRIPTION
I saw the comments in config-overrides about using the alias react -> preact only when u dont need to use the react browser extension to debug/develop and believe this is a more elegant solution.

Just only alias the packages when we are in production environment.