### PR TITLE
fix #138 countries graphql errors on explode

### DIFF
--- a/src/Plugin/DirectoryModel/SetStateRequired.php
+++ b/src/Plugin/DirectoryModel/SetStateRequired.php
@@ -113,13 +113,11 @@ class SetStateRequired
     {
         $store = $this->getStore();
         if (!$this->stateRequiredCountries) {
-            $configStateRequired = $this->scopeConfig->getValue(
+            $this->stateRequiredCountries = array_filter(explode(',', (string)$this->scopeConfig->getValue(
                 'general/region/state_required',
                 ScopeInterface::SCOPE_STORES,
                 $store->getCode()
-            );
-            if (!$configStateRequired) return [];
-            $this->stateRequiredCountries = explode(',', $configStateRequired);
+            )));
         }
         return $this->stateRequiredCountries;
     }

--- a/src/Plugin/DirectoryModel/SetStateRequired.php
+++ b/src/Plugin/DirectoryModel/SetStateRequired.php
@@ -113,11 +113,13 @@ class SetStateRequired
     {
         $store = $this->getStore();
         if (!$this->stateRequiredCountries) {
-            $this->stateRequiredCountries = explode(',', $this->scopeConfig->getValue(
+            $configStateRequired = $this->scopeConfig->getValue(
                 'general/region/state_required',
                 ScopeInterface::SCOPE_STORES,
                 $store->getCode()
-            ));
+            );
+            if (!$configStateRequired) return [];
+            $this->stateRequiredCountries = explode(',', $configStateRequired);
         }
         return $this->stateRequiredCountries;
     }


### PR DESCRIPTION
Hello, this PR fixes the throwing of an error when `general/region/state_required` isnt configured or is empty. In such cases it would now return an empty array for the countries of which state should be required.

We still need to document how and that developers should appropriately configure this option though!

as described in #138 