### PR TITLE
Change file to use `.min`

### DIFF
--- a/src/reactapp/vite.config.js
+++ b/src/reactapp/vite.config.js
@@ -16,7 +16,7 @@ export default defineConfig(({ mode }) => {
       lib: {
         formats: ['es'],
         entry: 'src/main.jsx',
-        fileName: 'react-checkout',
+        fileName: (format) => `react-checkout.${format}.min.js`,
         name: 'react-checkout.js',
       },
     },

--- a/src/view/frontend/layout/hyva_hyvacheckout_checkout_index.xml
+++ b/src/view/frontend/layout/hyva_hyvacheckout_checkout_index.xml
@@ -2,6 +2,6 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" layout="1column" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <head>
         <remove src="Hyva_Checkout::style.css" />
-        <remove src="Hyva_Checkout::react-checkout.es.js" />
+        <remove src="Hyva_Checkout::react-checkout.es.min.js" />
     </head>
 </page>

--- a/src/view/frontend/layout/hyvacheckout_checkout_index.xml
+++ b/src/view/frontend/layout/hyvacheckout_checkout_index.xml
@@ -2,7 +2,7 @@
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" layout="1column" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <head>
         <css src="Hyva_Checkout::style.css" defer="defer" />
-        <script src="Hyva_Checkout::react-checkout.es.js" defer="defer" />
+        <script src="Hyva_Checkout::react-checkout.es.min.js" defer="defer" />
     </head>
     <body>
         <referenceContainer name="content">

--- a/src/view/frontend/templates/react-script.phtml
+++ b/src/view/frontend/templates/react-script.phtml
@@ -17,7 +17,7 @@ use Magento\Framework\View\Element\Template;
         newScript.async = true;
         newScript.defer = true;
         newScript.type = 'module';
-        newScript.src = '<?= $escaper->escapeUrl($block->getViewFileUrl('Hyva_Checkout::react-checkout.es.js')); ?>';
+        newScript.src = '<?= $escaper->escapeUrl($block->getViewFileUrl('Hyva_Checkout::react-checkout.es.min.js')); ?>';
 
         firstScript.parentNode.insertBefore(newScript, firstScript);
     }


### PR DESCRIPTION
Vite automatically minifies the file but does not add `.min` to the name. If the filename does not include `.min` Magento will not recognize this and minify again when it's doing static deploy. This could lead to trouble because of different minification engines (esbuild is used by Vite).

This way it won't and Vite will do the job! 😄 